### PR TITLE
CI: add ubuntu-24.04-arm (arm64 Linux) to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macOS-latest
 
     steps:
@@ -29,6 +30,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macOS-latest
 
     steps:


### PR DESCRIPTION
GitHub offers free arm64 Linux runners for public repos. Add ubuntu-24.04-arm to both the quickbuild and gotest jobs so CI exercises the linux-arm64 config (the aarch64 toolchain, cross-compile, and the libxml2 probe/stub path), which until now was only tested by hand.

Claude-Session: https://claude.ai/code/session_01JWZxUBAh1StESqyT3qnu8N