### PR TITLE
systemdetect: detect arm64 CPUs from /proc/cpuinfo

### DIFF
--- a/systemdetect/cpuname_linux.go
+++ b/systemdetect/cpuname_linux.go
@@ -1,0 +1,209 @@
+package systemdetect
+
+import "fmt"
+
+// cpuPartName decodes an arm64 "CPU implementer" + "CPU part" pair into a human
+// readable core name (e.g. 0x41/0xd44 -> "Cortex-X1"). Unknown parts fall back
+// to the implementer name plus the raw part id, so detection degrades
+// gracefully on newer silicon instead of producing an empty string.
+//
+// The tables are ported from util-linux's lscpu (lib/cpu-arm.c), the de-facto
+// reference for /proc/cpuinfo id decoding.
+func cpuPartName(impl, part int) string {
+	if parts, ok := cpuParts[impl]; ok {
+		if name, ok := parts[part]; ok {
+			return name
+		}
+	}
+	return fmt.Sprintf("%s part 0x%03x", implementerName(impl), part)
+}
+
+func implementerName(impl int) string {
+	if name, ok := cpuImplementers[impl]; ok {
+		return name
+	}
+	return fmt.Sprintf("impl 0x%02x", impl)
+}
+
+var cpuImplementers = map[int]string{
+	0x41: "ARM",
+	0x42: "Broadcom",
+	0x43: "Cavium",
+	0x44: "DEC",
+	0x46: "Fujitsu",
+	0x48: "HiSilicon",
+	0x49: "Infineon",
+	0x4d: "Motorola/Freescale",
+	0x4e: "NVIDIA",
+	0x50: "APM",
+	0x51: "Qualcomm",
+	0x53: "Samsung",
+	0x56: "Marvell",
+	0x61: "Apple",
+	0x66: "Faraday",
+	0x69: "Intel",
+	0x6d: "Microsoft",
+	0x70: "Phytium",
+	0xc0: "Ampere",
+}
+
+// cpuParts maps implementer -> part id -> core name.
+var cpuParts = map[int]map[int]string{
+	// 0x41 ARM Ltd.
+	0x41: {
+		0x810: "ARM810",
+		0x920: "ARM920",
+		0x922: "ARM922",
+		0x926: "ARM926",
+		0x940: "ARM940",
+		0x946: "ARM946",
+		0x966: "ARM966",
+		0xa20: "ARM1020",
+		0xa22: "ARM1022",
+		0xa26: "ARM1026",
+		0xb02: "ARM11 MPCore",
+		0xb36: "ARM1136",
+		0xb56: "ARM1156",
+		0xb76: "ARM1176",
+		0xc05: "Cortex-A5",
+		0xc07: "Cortex-A7",
+		0xc08: "Cortex-A8",
+		0xc09: "Cortex-A9",
+		0xc0d: "Cortex-A17", // originally A12
+		0xc0f: "Cortex-A15",
+		0xc0e: "Cortex-A17",
+		0xc14: "Cortex-R4",
+		0xc15: "Cortex-R5",
+		0xc17: "Cortex-R7",
+		0xc18: "Cortex-R8",
+		0xc20: "Cortex-M0",
+		0xc21: "Cortex-M1",
+		0xc23: "Cortex-M3",
+		0xc24: "Cortex-M4",
+		0xc27: "Cortex-M7",
+		0xc60: "Cortex-M0+",
+		0xd01: "Cortex-A32",
+		0xd02: "Cortex-A34",
+		0xd03: "Cortex-A53",
+		0xd04: "Cortex-A35",
+		0xd05: "Cortex-A55",
+		0xd06: "Cortex-A65",
+		0xd07: "Cortex-A57",
+		0xd08: "Cortex-A72",
+		0xd09: "Cortex-A73",
+		0xd0a: "Cortex-A75",
+		0xd0b: "Cortex-A76",
+		0xd0c: "Neoverse-N1",
+		0xd0d: "Cortex-A77",
+		0xd0e: "Cortex-A76AE",
+		0xd13: "Cortex-R52",
+		0xd15: "Cortex-R82",
+		0xd16: "Cortex-R52+",
+		0xd20: "Cortex-M23",
+		0xd21: "Cortex-M33",
+		0xd40: "Neoverse-V1",
+		0xd41: "Cortex-A78",
+		0xd42: "Cortex-A78AE",
+		0xd43: "Cortex-A65AE",
+		0xd44: "Cortex-X1",
+		0xd46: "Cortex-A510",
+		0xd47: "Cortex-A710",
+		0xd48: "Cortex-X2",
+		0xd49: "Neoverse-N2",
+		0xd4a: "Neoverse-E1",
+		0xd4b: "Cortex-A78C",
+		0xd4c: "Cortex-X1C",
+		0xd4d: "Cortex-A715",
+		0xd4e: "Cortex-X3",
+		0xd4f: "Neoverse-V2",
+		0xd80: "Cortex-A520",
+		0xd81: "Cortex-A720",
+		0xd82: "Cortex-X4",
+		0xd83: "Neoverse-V3AE",
+		0xd84: "Neoverse-V3",
+		0xd85: "Cortex-X925",
+		0xd87: "Cortex-A725",
+		0xd88: "Cortex-A520AE",
+		0xd89: "Cortex-A720AE",
+		0xd8e: "Neoverse-N3",
+	},
+	// 0x42 Broadcom
+	0x42: {
+		0x00f: "Brahma-B15",
+		0x100: "Brahma-B53",
+		0x516: "ThunderX2",
+	},
+	// 0x43 Cavium
+	0x43: {
+		0x0a0: "ThunderX",
+		0x0a1: "ThunderX-88XX",
+		0x0a2: "ThunderX-81XX",
+		0x0a3: "ThunderX-83XX",
+		0x0af: "ThunderX2-99xx",
+		0x0b0: "OcteonTX2",
+		0x0b8: "ThunderX3-T110",
+	},
+	// 0x46 Fujitsu
+	0x46: {
+		0x001: "A64FX",
+	},
+	// 0x48 HiSilicon
+	0x48: {
+		0xd01: "TaiShan-v110", // Kunpeng-920
+		0xd02: "TaiShan-v120",
+		0xd40: "Cortex-A76", // used in Kirin SoCs
+		0xd41: "Cortex-A77",
+	},
+	// 0x4e NVIDIA
+	0x4e: {
+		0x000: "Denver",
+		0x003: "Denver 2",
+		0x004: "Carmel",
+	},
+	// 0x50 APM (Applied Micro)
+	0x50: {
+		0x000: "X-Gene",
+	},
+	// 0x51 Qualcomm
+	0x51: {
+		0x001: "Oryon",
+		0x00f: "Scorpion",
+		0x02d: "Scorpion",
+		0x04d: "Krait",
+		0x06f: "Krait",
+		0x201: "Kryo",
+		0x205: "Kryo",
+		0x211: "Kryo",
+		0x800: "Kryo-2XX-Gold", // Falkor V1
+		0x801: "Kryo-2XX-Silver",
+		0x802: "Kryo-3XX-Gold",
+		0x803: "Kryo-3XX-Silver",
+		0x804: "Kryo-4XX-Gold",
+		0x805: "Kryo-4XX-Silver",
+		0xc00: "Falkor",
+		0xc01: "Saphira",
+	},
+	// 0x53 Samsung
+	0x53: {
+		0x001: "exynos-m1",
+		0x002: "exynos-m3",
+		0x003: "exynos-m4",
+		0x004: "exynos-m5",
+	},
+	// 0x61 Apple
+	0x61: {
+		0x022: "Icestorm-M1",
+		0x023: "Firestorm-M1",
+		0x024: "Icestorm-M1-Pro",
+		0x025: "Firestorm-M1-Pro",
+		0x028: "Icestorm-M1-Max",
+		0x029: "Firestorm-M1-Max",
+		0x032: "Blizzard-M2",
+		0x033: "Avalanche-M2",
+	},
+	// 0xc0 Ampere
+	0xc0: {
+		0xac3: "Ampere-1",
+		0xac4: "Ampere-1a",
+	},
+}

--- a/systemdetect/detect_linux.go
+++ b/systemdetect/detect_linux.go
@@ -5,10 +5,109 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
 )
+
+// cpuinfoBlocks parses /proc/cpuinfo into one map per logical processor. Blocks
+// are separated by blank lines; each "key : value" pair becomes an entry with
+// the key and value trimmed. The final block is flushed at EOF even when the
+// file does not end with a blank line.
+func cpuinfoBlocks(r io.Reader) ([]map[string]string, error) {
+	var blocks []map[string]string
+	cur := map[string]string{}
+	flush := func() {
+		if len(cur) > 0 {
+			blocks = append(blocks, cur)
+			cur = map[string]string{}
+		}
+	}
+
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		cur[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	if s.Err() != nil {
+		return nil, fmt.Errorf("failed reading /proc/cpuinfo: %w", s.Err())
+	}
+	flush()
+	return blocks, nil
+}
+
+func Cpu() (string, error) {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	return parseCpuinfo(f)
+}
+
+// parseCpuinfo turns the contents of /proc/cpuinfo into a human readable CPU
+// description. Different architectures expose wildly different fields, so it
+// dispatches on the keys that are actually present:
+//
+//   - x86 exposes "model name" plus "physical id"/"cpu cores"/"siblings", which
+//     describe the socket/core/thread topology directly.
+//   - arm64 exposes no model name at all, only per-core "CPU implementer" and
+//     "CPU part" ids that must be decoded into core names (big.LITTLE systems
+//     report several distinct parts).
+func parseCpuinfo(r io.Reader) (string, error) {
+	blocks, err := cpuinfoBlocks(r)
+	if err != nil {
+		return "", err
+	}
+	if len(blocks) == 0 {
+		return "", fmt.Errorf("failed to parse /proc/cpuinfo")
+	}
+
+	switch {
+	case anyHasKey(blocks, "model name"):
+		return cpuX86(blocks)
+	case anyHasKey(blocks, "CPU part"):
+		return cpuARM(blocks)
+	default:
+		// Unknown architecture: at least report the logical CPU count.
+		n := len(blocks)
+		return fmt.Sprintf("%dC%dT %q", n, n, "unknown"), nil
+	}
+}
+
+func anyHasKey(blocks []map[string]string, key string) bool {
+	for _, b := range blocks {
+		if _, ok := b[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// atoiField parses an integer field. A missing field is treated as 0 (not an
+// error) so that CPUs which omit a field still parse; a present but malformed
+// value is reported as an error.
+func atoiField(b map[string]string, key string) (int, error) {
+	v, ok := b[key]
+	if !ok || v == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("bad %q: %q", key, v)
+	}
+	return n, nil
+}
 
 type socket struct {
 	name string
@@ -21,63 +120,26 @@ type cpuInfo struct {
 	threads int
 }
 
-func Cpu() (string, error) {
-	f, err := os.Open("/proc/cpuinfo")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
+// cpuX86 aggregates the classic x86 topology: "siblings" is the thread count
+// per socket, "cpu cores" the core count per socket, and "physical id" the
+// socket number. Identical model names across sockets are summed together.
+func cpuX86(blocks []map[string]string) (string, error) {
 	sockets := make(map[socket]cpuInfo)
-	s := bufio.NewScanner(f)
-	var (
-		name    string
-		id      int
-		cores   int
-		threads int
-	)
-	for s.Scan() {
-		line := s.Text()
-		if line == "" {
-			sockets[socket{name, id}] = cpuInfo{1, cores, threads}
-			continue
+	for _, b := range blocks {
+		name := b["model name"]
+		id, err := atoiField(b, "physical id")
+		if err != nil {
+			return "", err
 		}
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) != 2 {
-			return "", fmt.Errorf("invalid line: %q", line)
+		cores, err := atoiField(b, "cpu cores")
+		if err != nil {
+			return "", err
 		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		valueNum, valueErr := strconv.Atoi(value)
-		bad := false
-		switch key {
-		case "model name":
-			name = value
-		case "physical id":
-			if valueErr != nil {
-				bad = true
-			}
-			id = valueNum
-		case "siblings":
-			if valueErr != nil {
-				bad = true
-			}
-			threads = valueNum
-		case "cpu cores":
-			if valueErr != nil {
-				bad = true
-			}
-			cores = valueNum
+		threads, err := atoiField(b, "siblings")
+		if err != nil {
+			return "", err
 		}
-		if bad {
-			return "", fmt.Errorf("bad line: %q: %v", line, err)
-		}
-	}
-	if s.Err() != nil {
-		return "", fmt.Errorf("failed reading /proc/cpuinfo: %w", s.Err())
-	}
-	if len(sockets) == 0 {
-		return "", fmt.Errorf("failed to parse /proc/cpuinfo")
+		sockets[socket{name, id}] = cpuInfo{1, cores, threads}
 	}
 
 	models := make(map[string]cpuInfo)
@@ -89,8 +151,17 @@ func Cpu() (string, error) {
 			c.threads + i.threads,
 		}
 	}
+
+	// Sort model names so the output is deterministic regardless of map order.
+	names := make([]string, 0, len(models))
+	for name := range models {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	var parts []string
-	for name, info := range models {
+	for _, name := range names {
+		info := models[name]
 		var counts string
 		if info.sockets > 1 {
 			counts = fmt.Sprintf("%dS%dC%dT", info.sockets, info.cores, info.threads)
@@ -100,6 +171,82 @@ func Cpu() (string, error) {
 		parts = append(parts, fmt.Sprintf("%s %q", counts, name))
 	}
 	return strings.Join(parts, ";"), nil
+}
+
+// cpuCluster is a group of identical arm64 cores (same implementer + part).
+type cpuCluster struct {
+	impl int
+	part int
+}
+
+// cpuARM decodes the arm64 /proc/cpuinfo, which has no model name — only the
+// "CPU implementer" and "CPU part" ids of each logical core. arm64 has no SMT,
+// so the logical core count is also the physical core count. big.LITTLE SoCs
+// report several distinct parts; each becomes a "Nx <core name>" group.
+func cpuARM(blocks []map[string]string) (string, error) {
+	counts := make(map[cpuCluster]int)
+	var order []cpuCluster
+	total := 0
+	for _, b := range blocks {
+		partStr, ok := b["CPU part"]
+		if !ok {
+			continue
+		}
+		part, err := parseHexField(partStr)
+		if err != nil {
+			return "", fmt.Errorf("bad %q: %q", "CPU part", partStr)
+		}
+		impl, err := parseHexField(b["CPU implementer"])
+		if err != nil {
+			// implementer is optional for our purposes; default to 0 (unknown).
+			impl = 0
+		}
+		c := cpuCluster{impl, part}
+		if counts[c] == 0 {
+			order = append(order, c)
+		}
+		counts[c]++
+		total++
+	}
+	if total == 0 {
+		return "", fmt.Errorf("no CPU part entries found in /proc/cpuinfo")
+	}
+
+	// Sort clusters by descending part id so the largest/newest cores (which
+	// carry higher part numbers within a generation) are listed first, giving a
+	// stable "prime -> big -> little" ordering independent of core enumeration.
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].part != order[j].part {
+			return order[i].part > order[j].part
+		}
+		return order[i].impl < order[j].impl
+	})
+
+	var name string
+	if len(order) == 1 {
+		name = cpuPartName(order[0].impl, order[0].part)
+	} else {
+		clusters := make([]string, len(order))
+		for i, c := range order {
+			clusters[i] = fmt.Sprintf("%dx %s", counts[c], cpuPartName(c.impl, c.part))
+		}
+		name = strings.Join(clusters, " + ")
+	}
+
+	return fmt.Sprintf("%dC%dT %q", total, total, name), nil
+}
+
+// parseHexField parses a hexadecimal (or 0x-prefixed) /proc/cpuinfo value.
+func parseHexField(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	n, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
 }
 
 func Memory() (int64, error) {

--- a/systemdetect/detect_linux_test.go
+++ b/systemdetect/detect_linux_test.go
@@ -1,0 +1,178 @@
+package systemdetect
+
+import (
+	"strings"
+	"testing"
+)
+
+// blocks helper: repeat a processor block n times with a rising processor index,
+// keeping the remaining fields identical.
+func repeatBlock(n int, body string) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("processor\t: ")
+		b.WriteString(itoa(i))
+		b.WriteByte('\n')
+		b.WriteString(body)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	return string(digits)
+}
+
+func TestParseCpuinfoX86SingleSocket(t *testing.T) {
+	// 2 physical cores, 4 threads, one socket.
+	in := repeatBlock(4, `vendor_id	: GenuineIntel
+model name	: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
+physical id	: 0
+siblings	: 4
+cpu cores	: 2
+`)
+	got, err := parseCpuinfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `2C4T "Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseCpuinfoX86DualSocket(t *testing.T) {
+	// Two sockets, each 2 cores / 4 threads -> 2S4C8T.
+	body := func(id string) string {
+		return `model name	: Intel(R) Xeon(R) CPU
+physical id	: ` + id + `
+siblings	: 4
+cpu cores	: 2
+`
+	}
+	in := "processor\t: 0\n" + body("0") + "\n" +
+		"processor\t: 1\n" + body("0") + "\n" +
+		"processor\t: 2\n" + body("0") + "\n" +
+		"processor\t: 3\n" + body("0") + "\n" +
+		"processor\t: 4\n" + body("1") + "\n" +
+		"processor\t: 5\n" + body("1") + "\n" +
+		"processor\t: 6\n" + body("1") + "\n" +
+		"processor\t: 7\n" + body("1") + "\n"
+	got, err := parseCpuinfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `2S4C8T "Intel(R) Xeon(R) CPU"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// snapdragon888Cpuinfo mirrors the arm64 /proc/cpuinfo layout: no model name,
+// only implementer/part ids, one block per logical core.
+const snapdragon888Cpuinfo = `processor	: 0
+BogoMIPS	: 49.15
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x1
+CPU part	: 0xd44
+CPU revision	: 0
+
+processor	: 1
+CPU implementer	: 0x41
+CPU part	: 0xd41
+
+processor	: 2
+CPU implementer	: 0x41
+CPU part	: 0xd05
+
+processor	: 3
+CPU implementer	: 0x41
+CPU part	: 0xd05
+
+processor	: 4
+CPU implementer	: 0x41
+CPU part	: 0xd05
+
+processor	: 5
+CPU implementer	: 0x41
+CPU part	: 0xd05
+
+processor	: 6
+CPU implementer	: 0x41
+CPU part	: 0xd41
+
+processor	: 7
+CPU implementer	: 0x41
+CPU part	: 0xd41
+`
+
+func TestParseCpuinfoARMBigLittle(t *testing.T) {
+	got, err := parseCpuinfo(strings.NewReader(snapdragon888Cpuinfo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Clusters ordered by descending part id: X1 (0xd44), A78 (0xd41), A55 (0xd05).
+	want := `8C8T "1x Cortex-X1 + 3x Cortex-A78 + 4x Cortex-A55"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseCpuinfoARMHomogeneous(t *testing.T) {
+	// A homogeneous server part collapses to a single name (no "Nx" prefix).
+	in := repeatBlock(4, `CPU implementer	: 0x41
+CPU part	: 0xd0c
+`)
+	got, err := parseCpuinfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `4C4T "Neoverse-N1"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseCpuinfoARMUnknownPart(t *testing.T) {
+	// An unrecognized part falls back to implementer + raw id, never empty.
+	in := repeatBlock(2, `CPU implementer	: 0x41
+CPU part	: 0xfff
+`)
+	got, err := parseCpuinfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `2C2T "ARM part 0xfff"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseCpuinfoQualcommImplementer(t *testing.T) {
+	in := repeatBlock(2, `CPU implementer	: 0x51
+CPU part	: 0x804
+`)
+	got, err := parseCpuinfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `2C2T "Kryo-4XX-Gold"`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseCpuinfoEmpty(t *testing.T) {
+	if _, err := parseCpuinfo(strings.NewReader("")); err == nil {
+		t.Error("expected error for empty /proc/cpuinfo")
+	}
+}

--- a/systemdetect/detect_test.go
+++ b/systemdetect/detect_test.go
@@ -3,6 +3,7 @@ package systemdetect
 import (
 	"bytes"
 	"log"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +13,12 @@ func TestCpu(t *testing.T) {
 		t.Fatal("cannot get CPU information")
 	}
 	log.Println("detected CPU:", cpu)
+	// Guard against degenerate detections such as `0C0T ""`, which is what the
+	// arm64 path used to produce because /proc/cpuinfo has no x86 topology
+	// fields. A real CPU has at least one core and a non-empty name.
+	if strings.HasPrefix(cpu, "0C") || strings.HasSuffix(cpu, `""`) {
+		t.Errorf("degenerate CPU detection: %q", cpu)
+	}
 }
 
 func TestRam(t *testing.T) {


### PR DESCRIPTION
The Linux CPU detector only parsed x86 /proc/cpuinfo fields (model name, physical id, cpu cores, siblings), none of which exist on arm64, so detection produced `0C0T ""` on ARM machines (a linux-arm64 release target). Dispatch on the fields present: keep the x86 topology path, add an arm64 path that counts logical cores and decodes CPU implementer/part ids into core names (big.LITTLE clusters become "Nx <core>" groups), and fall back to the logical CPU count on unknown architectures.

Claude-Session: https://claude.ai/code/session_01JWZxUBAh1StESqyT3qnu8N