### PR TITLE
docs: add Windows PowerShell one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Append `-s -- --quick` for a quick build:
 curl -fsSL https://afq984.github.io/BenchmarkV3/run.sh | sh -s -- --quick
 ```
 
+On Windows, in PowerShell:
+
+```
+irm https://afq984.github.io/BenchmarkV3/run.ps1 | iex
+```
+
+For a quick build, invoke it as a scriptblock so the flag passes through:
+
+```
+& ([scriptblock]::Create((irm https://afq984.github.io/BenchmarkV3/run.ps1))) --quick
+```
+
 Or download the binary yourself from the [release page](https://github.com/afq984/BenchmarkV3/releases/tag/latest):
 
 ```

--- a/docs/run.ps1
+++ b/docs/run.ps1
@@ -1,0 +1,34 @@
+# Download and run the latest BenchmarkV3 prebuilt for this Windows machine.
+#
+#   irm https://afq984.github.io/BenchmarkV3/run.ps1 | iex
+#
+# To pass flags (e.g. a quick build), invoke it as a scriptblock so the
+# arguments reach the script:
+#
+#   & ([scriptblock]::Create((irm https://afq984.github.io/BenchmarkV3/run.ps1))) --quick
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"  # Invoke-WebRequest is far faster without it
+
+# OSArchitecture reports the native architecture even from an emulated process.
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+switch ($arch) {
+    "X64"   { $variant = "windows-amd64" }
+    "Arm64" { $variant = "windows-arm64" }
+    default {
+        Write-Error "BenchmarkV3: unsupported architecture: $arch (supported: x64, arm64)"
+        return
+    }
+}
+
+$url = "https://github.com/afq984/BenchmarkV3/releases/download/latest/BenchmarkV3-$variant.exe"
+$exe = Join-Path ([System.IO.Path]::GetTempPath()) "BenchmarkV3-$variant.exe"
+
+Write-Host "BenchmarkV3: downloading $variant ..."
+Invoke-WebRequest -Uri $url -OutFile $exe
+
+# No `exit`: this may be dot-sourced via `iex`, and exit would close the session.
+try {
+    & $exe @args
+} finally {
+    Remove-Item -Force -ErrorAction SilentlyContinue -Path $exe
+}


### PR DESCRIPTION
run.ps1 mirrors run.sh for Windows: it detects the OS architecture (x64/arm64) via RuntimeInformation.OSArchitecture, downloads the matching prebuilt .exe from the latest release, and runs it, passing flags through. It avoids `exit` so it is safe to dot-source via `iex`.

  irm https://afq984.github.io/BenchmarkV3/run.ps1 | iex

Validated end-to-end on a Win11 VM against the published binary, in both the `-File` and `[scriptblock]::Create` (flag-passing) forms.

Claude-Session: https://claude.ai/code/session_01JWZxUBAh1StESqyT3qnu8N